### PR TITLE
Fix Conda env creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ mamba activate tabm
 With Conda:
 
 ```
-conda create -f environment.yaml -n tabm
+conda env create -f environment.yaml -n tabm
 conda activate tabm
 ```
 


### PR DESCRIPTION
Use the env subcommand to create from an environment file.