### PR TITLE
Typo fix in classification example

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -102,7 +102,7 @@
     "# n_classes = 2\n",
     "# assert n_classes >= 2\n",
     "# task_type: TaskType = 'binclass' if n_classes == 2 else 'multiclass'\n",
-    "# x_num, Y = sklearn.datasets.make_classification(\n",
+    "# X_num, Y = sklearn.datasets.make_classification(\n",
     "#     n_samples=20000,\n",
     "#     n_features=8,\n",
     "#     n_classes=n_classes,\n",


### PR DESCRIPTION
Всего лишь поправил опечатку в `example.ipynb` примере. Ordnung muss sein.